### PR TITLE
Fixed issue 101 (NAs in the factor column were not shown correctly in the output)

### DIFF
--- a/py2r/data_converter.py
+++ b/py2r/data_converter.py
@@ -79,8 +79,7 @@ def convert_to_data(r_response, limit=20, is_table=False):
     else:
         type_name = r_response.typeof.name
     if is_factor:
-        isNA = isinstance(_array[0], NAIntegerType)
-        response =['NA'] if isNA else [r_response.levels[x - 1] for x in _array]
+        response = ['NA' if isinstance(x, NAIntegerType) else r_response.levels[x - 1] for x in _array]
         rett_type = 'array'
     elif type_name == 'REALSXP':
         response = [_clear_nan(x) for x in _array]


### PR DESCRIPTION
factor column NAs are now shown as expected (in the output).
Say if you try to print a factor column with NAs using the R syntax.
Example:
mtcars$cyl[1:5] 
Where 1:5 will contain 1 or more NAs.